### PR TITLE
Bump minimum Flutter version to 3.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,25 +8,21 @@ on:
 
 jobs:
   test:
-    name: Flutter ${{ matrix.channel }}${{ matrix.version }}
+    name: Flutter ${{ matrix.version }}
 
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - version: 2.10.x
-          - channel: stable
-          - channel: beta
+          version: ['3.3.10', '3.7.3']
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v1
         with:
-          channel: ${{ matrix.channel }}
           flutter-version: ${{ matrix.version }}
 
       - name: Flutter version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.0
+
+- Bump minimum Flutter version to 3.3.0.
+
 # 0.1.1
 - Loosen Dart SDK constraint to >=2.12.0
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -50,7 +50,7 @@ class MyHomePage extends StatelessWidget {
                 children: [
                   Text(
                     'Comment by user with ID: ${state.userId}',
-                    style: Theme.of(context).textTheme.overline,
+                    style: Theme.of(context).textTheme.labelSmall,
                   ),
                   Text(state.content),
                   Text('${state.upvotes} upvotes'),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  leancode_lint: ^1.0.2
+  leancode_lint: '>=2.1.0 < 2.2.0'
 
 flutter:
   uses-material-design: true

--- a/lib/bloc_presentation.dart
+++ b/lib/bloc_presentation.dart
@@ -1,5 +1,3 @@
-library bloc_presentation;
-
 export 'src/bloc_presentation_event.dart';
 export 'src/bloc_presentation_listener.dart';
 export 'src/bloc_presentation_mixin.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc_presentation
 description: Extends blocs with an additional stream which can serve as a way of indicating single-time events (so-called "presentation events").
-version: 0.1.1
+version: 0.2.0
 homepage: https://github.com/leancodepl/bloc_presentation
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,5 +18,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  leancode_lint: ^1.0.2
+  leancode_lint: '>=2.1.0 <2.2.0'
   mocktail: ^0.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,7 @@ homepage: https://github.com/leancodepl/bloc_presentation
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
+  flutter: '>=3.3.0'
 
 dependencies:
   flutter:

--- a/test/fakes.dart
+++ b/test/fakes.dart
@@ -5,6 +5,7 @@ import 'package:mocktail/mocktail.dart';
 class _FakeBuildContext extends Fake implements BuildContext {}
 
 class _FakeBlocPresentationEvent extends Fake implements BlocPresentationEvent {
+  // Flutter 3.3 and 3.7 format this class differently, hence the comment...
 }
 
 void registerFakes() {


### PR DESCRIPTION
This is motivated mainly because of the compatibility with our lints