### PR TITLE
Bump dependency on `flutter_hooks`

### DIFF
--- a/.github/workflows/bloc_presentation-test.yml
+++ b/.github/workflows/bloc_presentation-test.yml
@@ -3,7 +3,7 @@ name: bloc_presentation test
 on:
   push:
     branches: [master]
-    ignore-tags: ['bloc_presentation-v*']
+    tags-ignore: ['bloc_presentation-v*']
     paths:
       - 'packages/bloc_presentation/**'
       - .github/workflows/bloc_presentation-test.yml

--- a/.github/workflows/bloc_presentation-test.yml
+++ b/.github/workflows/bloc_presentation-test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['3.3.x', '3.7.x']
+        version: ['3.3.x', '3.7.x', '3.10.x']
 
     defaults:
       run:

--- a/.github/workflows/bloc_presentation-test.yml
+++ b/.github/workflows/bloc_presentation-test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['3.3.x', '3.7.x', '3.10.x']
+        version: ['3.10.x']
 
     defaults:
       run:

--- a/.github/workflows/bloc_presentation_test-test.yml
+++ b/.github/workflows/bloc_presentation_test-test.yml
@@ -3,7 +3,7 @@ name: bloc_presentation_test test
 on:
   push:
     branches: [master]
-    ignore-tags: ['bloc_presentation_test-v*']
+    tags-ignore: ['bloc_presentation_test-v*']
     paths:
       - 'packages/bloc_presentation_test/**'
       - .github/workflows/bloc_presentation_test-test.yml

--- a/.github/workflows/bloc_presentation_test-test.yml
+++ b/.github/workflows/bloc_presentation_test-test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['3.3.x', '3.7.x']
+        version: ['3.3.x', '3.7.x', '3.10.x']
 
     defaults:
       run:

--- a/.github/workflows/bloc_presentation_test-test.yml
+++ b/.github/workflows/bloc_presentation_test-test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['3.3.x', '3.7.x', '3.10.x']
+        version: ['3.10.x']
 
     defaults:
       run:

--- a/packages/bloc_presentation/CHANGELOG.md
+++ b/packages/bloc_presentation/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Unreleased
 
-- Bump `flutter_hooks` to `^0.19.0` (#22)
+- Bump dependencies (#22)
+  - Bump minimum Flutter version to `3.10.0`
+  - Bump dependency on `flutter_hooks` to `^0.20.0`
+  - Bump dependency on `leancode_lint` to `^5.0.0`
+  - Bump dependency on `mocktail` to `^1.0.0`
 
 # 0.2.1+2
 

--- a/packages/bloc_presentation/CHANGELOG.md
+++ b/packages/bloc_presentation/CHANGELOG.md
@@ -1,10 +1,7 @@
 # Unreleased
 
-- Bump dependencies (#22)
-  - Bump minimum Flutter version to `3.10.0`
-  - Bump dependency on `flutter_hooks` to `^0.20.0`
-  - Bump dependency on `leancode_lint` to `^5.0.0`
-  - Bump dependency on `mocktail` to `^1.0.0`
+- Bump minimum Flutter version to `3.10.0` (#22)
+- Bump dependency on `flutter_hooks` to `^0.20.0` (#22)
 
 # 0.2.1+2
 

--- a/packages/bloc_presentation/CHANGELOG.md
+++ b/packages/bloc_presentation/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Bump `flutter_hooks` to `^0.19.0` (#22)
+
 # 0.2.1+2
 
 - Fix example path in README

--- a/packages/bloc_presentation/example/lib/main.dart
+++ b/packages/bloc_presentation/example/lib/main.dart
@@ -8,7 +8,7 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -24,7 +24,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatelessWidget {
-  const MyHomePage({Key? key}) : super(key: key);
+  const MyHomePage({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/packages/bloc_presentation/example/pubspec.yaml
+++ b/packages/bloc_presentation/example/pubspec.yaml
@@ -18,7 +18,7 @@ dev_dependencies:
   bloc_test: ^9.1.2
   flutter_test:
     sdk: flutter
-  leancode_lint: '>=5.0.0'
+  leancode_lint: '^5.0.0'
 
 flutter:
   uses-material-design: true

--- a/packages/bloc_presentation/example/pubspec.yaml
+++ b/packages/bloc_presentation/example/pubspec.yaml
@@ -19,7 +19,7 @@ dev_dependencies:
   bloc_test: 9.1.2
   flutter_test:
     sdk: flutter
-  leancode_lint: '>=2.1.0 < 2.2.0'
+  leancode_lint: '>=5.0.0'
 
 flutter:
   uses-material-design: true

--- a/packages/bloc_presentation/example/pubspec.yaml
+++ b/packages/bloc_presentation/example/pubspec.yaml
@@ -1,12 +1,11 @@
 name: bloc_presentation_example
 description: A new Flutter project.
-
-publish_to: 'none'
-
+publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.15.1 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: '>=3.10.0'
 
 dependencies:
   bloc_presentation:
@@ -16,7 +15,7 @@ dependencies:
   flutter_bloc: ^8.0.0
 
 dev_dependencies:
-  bloc_test: 9.1.2
+  bloc_test: ^9.1.2
   flutter_test:
     sdk: flutter
   leancode_lint: '>=5.0.0'

--- a/packages/bloc_presentation/lib/src/bloc_presentation_listener.dart
+++ b/packages/bloc_presentation/lib/src/bloc_presentation_listener.dart
@@ -22,11 +22,11 @@ class BlocPresentationListener<B extends BlocPresentationMixin<dynamic>>
     extends SingleChildStatelessWidget {
   /// {@macro bloc_presentation_listener}
   const BlocPresentationListener({
-    Key? key,
+    super.key,
     this.bloc,
     required this.listener,
-    Widget? child,
-  }) : super(key: key, child: child);
+    super.child,
+  });
 
   /// The [bloc] that the [BlocPresentationListener] will interact with.
   /// If omitted, [BlocPresentationListener] will automatically perform a lookup using

--- a/packages/bloc_presentation/pubspec.yaml
+++ b/packages/bloc_presentation/pubspec.yaml
@@ -20,5 +20,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  leancode_lint: '>=2.1.0 <2.2.0'
-  mocktail: ^0.3.0
+  leancode_lint: '>=5.0.0'
+  mocktail: ^1.0.0

--- a/packages/bloc_presentation/pubspec.yaml
+++ b/packages/bloc_presentation/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_bloc: ^8.0.0
-  flutter_hooks: ^0.18.1
+  flutter_hooks: ^0.19.0
   nested: ^1.0.0
   provider: ^6.0.1
 

--- a/packages/bloc_presentation/pubspec.yaml
+++ b/packages/bloc_presentation/pubspec.yaml
@@ -6,8 +6,8 @@ version: 0.2.1+2
 homepage: https://github.com/leancodepl/bloc_presentation/tree/master/packages/bloc_presentation
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: '>=3.3.0'
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: '>=3.10.0'
 
 dependencies:
   flutter:

--- a/packages/bloc_presentation/pubspec.yaml
+++ b/packages/bloc_presentation/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_bloc: ^8.0.0
-  flutter_hooks: ^0.19.0
+  flutter_hooks: ^0.20.0
   nested: ^1.0.0
   provider: ^6.0.1
 

--- a/packages/bloc_presentation_test/.gitignore
+++ b/packages/bloc_presentation_test/.gitignore
@@ -23,7 +23,7 @@ migrate_working_dir/
 
 # Flutter/Dart/Pub related
 # Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
-/pubspec.lock
+pubspec.lock
 **/doc/api/
 .dart_tool/
 .packages

--- a/packages/bloc_presentation_test/CHANGELOG.md
+++ b/packages/bloc_presentation_test/CHANGELOG.md
@@ -1,9 +1,6 @@
 # Unreleased
 
-- Bump dependencies (#22)
-  - Bump minimum Flutter version to `3.10.0`
-  - Bump dependency on `leancode_lint` to `^5.0.0`
-  - Bump dependency on `mocktail` to `^1.0.0`
+- Bump minimum Flutter version to `3.10.0` (#22)
 
 # 0.1.1
 

--- a/packages/bloc_presentation_test/CHANGELOG.md
+++ b/packages/bloc_presentation_test/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+- Bump dependencies (#22)
+  - Bump minimum Flutter version to `3.10.0`
+  - Bump dependency on `leancode_lint` to `^5.0.0`
+  - Bump dependency on `mocktail` to `^1.0.0`
+
 # 0.1.1
 
 - Increase max Dart version constraint to 4.0.0.
@@ -5,4 +12,5 @@
 
 # 0.1.0
 
-- Initial release. Includes `MockPresentationBloc` / `MockPresentationCubit` and `whenListenPresentation`.
+- Initial release. Includes `MockPresentationBloc` / `MockPresentationCubit` and
+  `whenListenPresentation`.

--- a/packages/bloc_presentation_test/CHANGELOG.md
+++ b/packages/bloc_presentation_test/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Bump minimum Flutter version to `3.10.0` (#22)
+- Bump dependency on `mocktail` to `^1.0.0` (#22)
 
 # 0.1.1
 

--- a/packages/bloc_presentation_test/CHANGELOG.md
+++ b/packages/bloc_presentation_test/CHANGELOG.md
@@ -9,5 +9,4 @@
 
 # 0.1.0
 
-- Initial release. Includes `MockPresentationBloc` / `MockPresentationCubit` and
-  `whenListenPresentation`.
+- Initial release. Includes `MockPresentationBloc` / `MockPresentationCubit` and `whenListenPresentation`.

--- a/packages/bloc_presentation_test/example/pubspec.yaml
+++ b/packages/bloc_presentation_test/example/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   test: ^1.24.3
 
 dev_dependencies:
-  leancode_lint: '>=2.1.0 < 2.2.0'
+  leancode_lint: '>=5.0.0'
 
 dependency_overrides:
   bloc_presentation:

--- a/packages/bloc_presentation_test/example/pubspec.yaml
+++ b/packages/bloc_presentation_test/example/pubspec.yaml
@@ -1,12 +1,11 @@
 name: bloc_presentation_test_example
 description: bloc_presentation_test example
-
-publish_to: 'none'
-
+publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.15.1 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: '>=3.10.0'
 
 dependencies:
   bloc: ^8.0.0

--- a/packages/bloc_presentation_test/lib/src/when_listen_presentation.dart
+++ b/packages/bloc_presentation_test/lib/src/when_listen_presentation.dart
@@ -10,7 +10,7 @@ import 'package:mocktail/mocktail.dart';
 /// [initialEvents] can be provided for stubbing bloc's presentation stream
 /// before subscribing to bloc's presentation stream.
 StreamController<T> whenListenPresentation<T extends BlocPresentationEvent>(
-  BlocPresentationMixin<T> bloc, {
+  BlocPresentationMixin<dynamic> bloc, {
   List<T>? initialEvents,
 }) {
   final presentationController = StreamController<T>();

--- a/packages/bloc_presentation_test/lib/src/when_listen_presentation.dart
+++ b/packages/bloc_presentation_test/lib/src/when_listen_presentation.dart
@@ -10,7 +10,7 @@ import 'package:mocktail/mocktail.dart';
 /// [initialEvents] can be provided for stubbing bloc's presentation stream
 /// before subscribing to bloc's presentation stream.
 StreamController<T> whenListenPresentation<T extends BlocPresentationEvent>(
-  BlocPresentationMixin bloc, {
+  BlocPresentationMixin<T> bloc, {
   List<T>? initialEvents,
 }) {
   final presentationController = StreamController<T>();

--- a/packages/bloc_presentation_test/pubspec.yaml
+++ b/packages/bloc_presentation_test/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   bloc_presentation: ^0.2.1+1
   flutter:
     sdk: flutter
-  mocktail: ^0.3.0
+  mocktail: ^1.0.0
 
 dev_dependencies:
-  leancode_lint: '>=2.1.0 <2.2.0'
+  leancode_lint: '>=5.0.0'

--- a/packages/bloc_presentation_test/pubspec.yaml
+++ b/packages/bloc_presentation_test/pubspec.yaml
@@ -4,7 +4,8 @@ version: 0.1.1
 homepage: https://github.com/leancodepl/bloc_presentation/tree/master/packages/bloc_presentation_test
 
 environment:
-  sdk: '>=2.12.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: '>=3.10.0'
 
 dependencies:
   bloc: ^8.0.0


### PR DESCRIPTION
Fixes conflict with the newest version of `flutter_hooks`:

```
[discover_rudy] flutter pub get
Resolving dependencies...
Because bloc_presentation 0.2.1+1 depends on flutter_hooks ^0.18.1 and no versions of bloc_presentation match >0.2.1+1 <0.3.0, bloc_presentation ^0.2.1+1 requires flutter_hooks ^0.18.1.
So, because discover_rudy depends on both bloc_presentation ^0.2.1+1 and flutter_hooks ^0.19.0, version solving failed.
exit code 1
````