### PR TITLE
Make MockPresentation{Cubit,Bloc} stream a broadcast one

### DIFF
--- a/packages/bloc_presentation_test/CHANGELOG.md
+++ b/packages/bloc_presentation_test/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.1.0
+# 1.0.1
 
 - Make `MockPresentationCubit` and `MockPresentationBloc` presentation streams broadcast ones.
 

--- a/packages/bloc_presentation_test/CHANGELOG.md
+++ b/packages/bloc_presentation_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.0
+
+- Make `MockPresentationCubit` and `MockPresentationBloc` presentation streams broadcast ones.
+
 # 1.0.0
 
 - Bump dependency on `bloc_presentation` to `^1.0.0`

--- a/packages/bloc_presentation_test/lib/src/mock_presentation_bloc.dart
+++ b/packages/bloc_presentation_test/lib/src/mock_presentation_bloc.dart
@@ -24,7 +24,7 @@ class _MockPresentationBlocBase<S, P> extends Mock
     when(close).thenAnswer((_) => _presentationController.close());
   }
 
-  final _presentationController = StreamController<P>();
+  final _presentationController = StreamController<P>.broadcast();
 
   /// Adds given [event] to bloc's presentation stream.
   void emitMockPresentation(P event) {

--- a/packages/bloc_presentation_test/pubspec.yaml
+++ b/packages/bloc_presentation_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc_presentation_test
 description: A testing library for Blocs/Cubits which mixin BlocPresentationMixin. To be used with bloc_presentation package.
-version: 1.1.0
+version: 1.0.1
 homepage: https://github.com/leancodepl/bloc_presentation/tree/master/packages/bloc_presentation_test
 
 environment:

--- a/packages/bloc_presentation_test/pubspec.yaml
+++ b/packages/bloc_presentation_test/pubspec.yaml
@@ -1,11 +1,11 @@
 name: bloc_presentation_test
 description: A testing library for Blocs/Cubits which mixin BlocPresentationMixin. To be used with bloc_presentation package.
-version: 1.0.0
+version: 1.1.0
 homepage: https://github.com/leancodepl/bloc_presentation/tree/master/packages/bloc_presentation_test
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
-  flutter: '>=3.10.0'
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   bloc: ^8.0.0
@@ -19,4 +19,4 @@ dependencies:
 
 dev_dependencies:
   equatable: ^2.0.5
-  leancode_lint: '>=5.0.0'
+  leancode_lint: ">=5.0.0"

--- a/packages/bloc_presentation_test/test/bloc_presentation_test_test.dart
+++ b/packages/bloc_presentation_test/test/bloc_presentation_test_test.dart
@@ -241,6 +241,20 @@ void main() {
           expect((actualError as TestFailure).message, expectedError);
         },
       );
+
+      test('allows to listen to presentation stream three times', () {
+        final cubit = CounterCubit();
+
+        final subs = [
+          cubit.presentation.listen((_) {}),
+          cubit.presentation.listen((_) {}),
+          cubit.presentation.listen((_) {}),
+        ];
+
+        for (final subscription in subs) {
+          subscription.cancel();
+        }
+      });
     });
 
     group('AsyncCounterCubit', () {


### PR DESCRIPTION
When widget testing a widget that uses two or more `BlocPresentationListener` for the same cubit, using a `MockPresentation{Bloc,Cubit}`, it fails due to listening to the same (non-broadcast) same a few times.