### PR TITLE
Remove direct dependency on `provider`

### DIFF
--- a/packages/bloc_presentation/CHANGELOG.md
+++ b/packages/bloc_presentation/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.1
+
+- Removed dependency on `provider`.
+
 # 1.0.0
 
 - **BREAKING**: Removed `useBlocPresentationListener` hook. Use `useOnStreamChanged` from `flutter_hooks` instead.

--- a/packages/bloc_presentation/pubspec.yaml
+++ b/packages/bloc_presentation/pubspec.yaml
@@ -14,7 +14,6 @@ dependencies:
     sdk: flutter
   flutter_bloc: ^8.0.0
   nested: ^1.0.0
-  provider: ^6.0.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/bloc_presentation/pubspec.yaml
+++ b/packages/bloc_presentation/pubspec.yaml
@@ -2,7 +2,7 @@ name: bloc_presentation
 description: >
   Extends blocs with an additional stream which can serve as a way of indicating
   single-time events (so-called "presentation events").
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/leancodepl/bloc_presentation/tree/master/packages/bloc_presentation
 
 environment:

--- a/packages/bloc_presentation/test/bloc_presentation_listener_test.dart
+++ b/packages/bloc_presentation/test/bloc_presentation_listener_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:provider/provider.dart';
 
 import 'fakes.dart';
 
@@ -60,7 +59,7 @@ void main() {
 
     testWidgets('Correctly fallsback to the Provider cubit', (tester) async {
       await tester.pumpWidget(
-        Provider<_TestCubit>.value(
+        BlocProvider<_TestCubit>.value(
           value: cubit,
           child: BlocPresentationListener<_TestCubit, _PresentationEvent>(
             listener: listener,


### PR DESCRIPTION
There is only one explicit usage of `package:provider` and it's in a test. We can as well just get rid of it.