### PR TITLE
Bump dependencies on flutter_bloc 9.0.0 and bloc_test 10.0.0

### DIFF
--- a/packages/bloc_presentation/example/pubspec.yaml
+++ b/packages/bloc_presentation/example/pubspec.yaml
@@ -12,10 +12,10 @@ dependencies:
     path: ..
   flutter:
     sdk: flutter
-  flutter_bloc: ^8.0.0
+  flutter_bloc: ^9.0.0
 
 dev_dependencies:
-  bloc_test: ^9.1.2
+  bloc_test: ^10.0.0
   flutter_test:
     sdk: flutter
   leancode_lint: ">=5.0.0 <7.0.0"

--- a/packages/bloc_presentation/lib/src/bloc_presentation_mixin.dart
+++ b/packages/bloc_presentation/lib/src/bloc_presentation_mixin.dart
@@ -3,9 +3,9 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-/// [BlocPresentationMixin] adds a presentation stream to a [BlocBase]
+/// [BlocPresentationMixin] adds a presentation stream to a [EmittableStateStreamableSource]
 /// which is automatically disposed.
-mixin BlocPresentationMixin<S, P> on BlocBase<S> {
+mixin BlocPresentationMixin<S, P> on EmittableStateStreamableSource<S> {
   final _presentationStream = StreamController<P>.broadcast();
 
   /// Stream emitting non-unique presentation events.

--- a/packages/bloc_presentation/pubspec.yaml
+++ b/packages/bloc_presentation/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_bloc: ^8.0.0
+  flutter_bloc: ^9.0.0
   nested: ^1.0.0
 
 dev_dependencies:


### PR DESCRIPTION
Add Support for the newest bloc release:
https://github.com/felangel/bloc/releases/tag/flutter_bloc-v9.0.0
https://github.com/felangel/bloc/releases/tag/bloc_test-v10.0.0